### PR TITLE
Enforce user attempts for conversation

### DIFF
--- a/simcon_project/conversation_templates/views/conversation.py
+++ b/simcon_project/conversation_templates/views/conversation.py
@@ -1,5 +1,6 @@
 import os
-
+import django_tables2 as tables
+import secrets
 from django.core.files.storage import default_storage
 from django.shortcuts import render, redirect
 from django.utils import timezone
@@ -10,7 +11,6 @@ from conversation_templates.forms import TemplateNodeChoiceForm
 from users.models import Student, Assignment
 from django.contrib.auth.decorators import user_passes_test
 from users.views.student_home import is_student
-import django_tables2 as tables
 
 # Globals
 ct_templates_dir = 'conversation'
@@ -55,6 +55,8 @@ def flush_session_data(request):
         del request.session['assign_id']
     if 'ct_node_response_id' in request.session:
         del request.session['ct_node_response_id']
+    if 'validation_key' in request.session:
+        del request.session['validation_key']
     request.session.modified = True
 
 
@@ -64,6 +66,14 @@ def conversation_start(request, ct_id, assign_id):
     """
     Renders entry page for a conversation. Student can choose to start the conversation or go back.
     """
+    # Check if user has retries
+    assignment = Assignment.objects.get(id=assign_id)
+    student = Student.objects.get(email=request.user)
+    student_attempts = TemplateResponse.objects.filter(student=student, assignment=assignment).count()
+    if student_attempts >= assignment.attempts:
+        return HttpResponseNotFound('<h1>Sorry, maximum number of attempts reached for this conversation.</h1>')
+
+    # Else, set up conversation
     ctx = {}
     t = '{}/conversation_start.html'.format(ct_templates_dir)
     ct = ConversationTemplate.objects.get(id=ct_id)
@@ -73,6 +83,7 @@ def conversation_start(request, ct_id, assign_id):
     flush_session_data(request)
     request.session['assign_id'] = assign_id
     request.session['page_dict'] = {}
+    request.session['validation_key'] = secrets.token_hex(8)
     ctx.update({
         'ct': ct,
         'ct_node': ct_node,
@@ -86,6 +97,11 @@ def conversation_step(request, ct_node_id):
     Renders each step in a conversation where a Student can watch the video, record a response,
     and select a choice.
     """
+    # Check to make sure student didn't copy paste old conversation link
+    if request.session.get('validation_key') is None:
+        return HttpResponseNotFound('<h1>Access Denied</h1>')
+
+    # Else, set up TemplateNode data
     ctx = {}
     t = '{}/conversation_step.html'.format(ct_templates_dir)
     ct_node = TemplateNode.objects.get(id=ct_node_id)
@@ -208,6 +224,9 @@ def conversation_end(request, ct_response_id):
         return redirect('student-view')
 
     # GET request
+    if 'validation_key' in request.session:
+        del request.session['validation_key']
+        request.session.modified = True
     ctx.update({
         'ct': ct,
         'ct_response': ct_response,

--- a/simcon_project/users/models/assignment.py
+++ b/simcon_project/users/models/assignment.py
@@ -22,6 +22,7 @@ class Assignment(models.Model):
     students = models.ManyToManyField('users.Student', related_name='assignments')
     researcher = models.ForeignKey('users.Researcher', default=0, related_name='assignments', on_delete=models.CASCADE)
     subject_labels = models.ManyToManyField('users.SubjectLabel', related_name='assignments', blank=True)
+    attempts = models.IntegerField(default=1)
 
     def get_name(self):
         return self.name

--- a/simcon_project/users/views/student_home.py
+++ b/simcon_project/users/views/student_home.py
@@ -36,6 +36,10 @@ def student_view(request):
     :param request:
     :return: student_view.html with table
     """
+    # Clear conversation validation key if user returns to home page without finishing conversation
+    if 'validation_key' in request.session:
+        del request.session['validation_key']
+        request.session.modified = True
     assigned_templates = []
     # get the Student object matching logged in student
     student = Student.objects.filter(id=request.user.id)


### PR DESCRIPTION
**Note**: devin/SYMCO-31 branch also has `attempts` defined for Assignment model. Would like to merge his branch first.
https://github.com/Likhovodov/Simulated-Conversations/pull/36

To test:

- Run migrations
- Create the usual assignment and friends
- Make sure to set the assignment attempts to what you desire (default is 1)
- Try starting a conversation after attempts has been reached
- Try copy pasta an old convo link when on some non-convo related page