### PR TITLE
Edit templates (symco 47)

### DIFF
--- a/simcon_project/conversation_templates/forms.py
+++ b/simcon_project/conversation_templates/forms.py
@@ -65,4 +65,4 @@ class TemplateNodeChoiceForm(forms.Form):
     def __init__(self, *args, **kwargs):
         ct_node = kwargs.pop('ct_node', None)
         super(TemplateNodeChoiceForm, self).__init__(*args, **kwargs)
-        self.fields['choices'].queryset = TemplateNodeChoice.objects.filter(parent_template=ct_node)
+        self.fields['choices'].queryset = TemplateNodeChoice.objects.filter(parent_template_node=ct_node)

--- a/simcon_project/conversation_templates/models/conv_template.py
+++ b/simcon_project/conversation_templates/models/conv_template.py
@@ -22,4 +22,4 @@ class ConversationTemplate(models.Model):
     researcher = models.ForeignKey('users.Researcher', related_name='templates', default=0, on_delete=models.CASCADE)
 
     def __str__(self):
-        return self.name
+        return f"{self.id}" # TODO: Undo

--- a/simcon_project/conversation_templates/models/conv_template.py
+++ b/simcon_project/conversation_templates/models/conv_template.py
@@ -22,4 +22,4 @@ class ConversationTemplate(models.Model):
     researcher = models.ForeignKey('users.Researcher', related_name='templates', default=0, on_delete=models.CASCADE)
 
     def __str__(self):
-        return f"{self.id}" # TODO: Undo
+        return f"{self.name}"

--- a/simcon_project/conversation_templates/models/template_node_choice.py
+++ b/simcon_project/conversation_templates/models/template_node_choice.py
@@ -10,12 +10,12 @@ class TemplateNodeChoice(models.Model):
     id: Primary key id for TemplateNodeChoice object
     choice_text: A text description for the Choice object
     destination_node: The TemplateNode object that a Choice object leads to
-    parent_template: The TemplateNode object that a Choice object belongs to
+    parent_template_node: The TemplateNode object that a Choice object belongs to
     """
     id = models.UUIDField(unique=True, editable=False, primary_key=True, default=uuid.uuid4)
     choice_text = models.CharField(max_length=500)
     destination_node = models.ForeignKey('conversation_templates.TemplateNode', default=0, null=True, blank=True, related_name='parent_choices', on_delete=models.CASCADE)
-    parent_template = models.ForeignKey('conversation_templates.TemplateNode', default=0, related_name='choices', on_delete=models.CASCADE)
+    parent_template_node = models.ForeignKey('conversation_templates.TemplateNode', default=0, related_name='choices', on_delete=models.CASCADE)
 
     def __str__(self):
         return self.choice_text

--- a/simcon_project/conversation_templates/tests/test_template_management.py
+++ b/simcon_project/conversation_templates/tests/test_template_management.py
@@ -98,8 +98,8 @@ class TemplateManagementTests(TestCase):
                                             , video_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ")
         node2 = TemplateNode.objects.create(description='Node', parent_template=self.template1
                                             , video_url="https://www.youtube.com/watch?v=dQw4w9WgXcQ")
-        TemplateNodeChoice.objects.create(parent_template=start_node, destination_node=node1)
-        TemplateNodeChoice.objects.create(parent_template=start_node, destination_node=node2)
+        TemplateNodeChoice.objects.create(parent_template_node=start_node, destination_node=node1)
+        TemplateNodeChoice.objects.create(parent_template_node=start_node, destination_node=node2)
         label = SubjectLabel.objects.create(label_name='label', researcher=self.researcher)
         label.students.set([student])
         assignment1 = Assignment.objects.create(name='assignment', date_assigned=date.today(),

--- a/simcon_project/conversation_templates/urls/templates_urls.py
+++ b/simcon_project/conversation_templates/urls/templates_urls.py
@@ -11,5 +11,6 @@ urlpatterns = [
     path('delete/<uuid:pk>/', TemplateDeleteView.as_view(), name="delete-template"),
     path('folder/remove/<uuid:pk>/', remove_template, name="remove-template"),
     path('new/', create_conversation_template_view, name="create-conversation-template-view"),
+    path('edit/<uuid:pk>/', edit_conversation_template, name="edit_conversation_template"),
     path('redirect/template/', RedirectToTemplateCreation.as_view(), name="redirect-to-template-creation"),
 ]

--- a/simcon_project/conversation_templates/views/__init__.py
+++ b/simcon_project/conversation_templates/views/__init__.py
@@ -1,4 +1,5 @@
 from .conversation import *
-from .create_conversation_template import *
+from .create_conversation_template_view import *
+from .edit_conversation_template_view import *
 from .template_management import *
 from .template_responses_table import TemplateResponsesView

--- a/simcon_project/conversation_templates/views/conversation.py
+++ b/simcon_project/conversation_templates/views/conversation.py
@@ -131,7 +131,7 @@ def conversation_step(request, ct_node_id):
 
     # GET request
     choice_form = TemplateNodeChoiceForm(ct_node=ct_node)
-    ct = ct_node.parent_template
+    ct = ct_node.parent_template_node
 
     # Check for page refresh
     if ct_node.start and request.session.get('ct_response_id') is None:

--- a/simcon_project/conversation_templates/views/conversation.py
+++ b/simcon_project/conversation_templates/views/conversation.py
@@ -131,7 +131,7 @@ def conversation_step(request, ct_node_id):
 
     # GET request
     choice_form = TemplateNodeChoiceForm(ct_node=ct_node)
-    ct = ct_node.parent_template_node
+    ct = ct_node.parent_template
 
     # Check for page refresh
     if ct_node.start and request.session.get('ct_response_id') is None:

--- a/simcon_project/conversation_templates/views/create_conversation_template_view.py
+++ b/simcon_project/conversation_templates/views/create_conversation_template_view.py
@@ -43,7 +43,7 @@ def create_conversation_template_view(request):
             for choice in received_node[1]['responseChoices']:
                 TemplateNodeChoice(
                     choice_text=choice['description'],
-                    parent_template=stored_nodes_dict.get(received_node[0]),
+                    parent_template_node=stored_nodes_dict.get(received_node[0]),
                     destination_node=stored_nodes_dict.get(choice['destinationIndex'])).save()
 
         return HttpResponse(status=202)

--- a/simcon_project/conversation_templates/views/edit_conversation_template_view.py
+++ b/simcon_project/conversation_templates/views/edit_conversation_template_view.py
@@ -1,0 +1,43 @@
+import json
+from django.shortcuts import render
+from django.http import HttpResponseNotFound, HttpResponse
+from django.contrib.auth.decorators import user_passes_test
+from users.views.researcher_home import is_researcher
+from django.views.decorators.csrf import ensure_csrf_cookie
+from conversation_templates.models import TemplateNodeChoice, TemplateNode, ConversationTemplate
+from users.models import Researcher
+
+
+@user_passes_test(is_researcher)
+@ensure_csrf_cookie  # guarantees csrf cookie is generated even though html does not contain {% csrf_token %}
+def edit_conversation_template(request, pk):
+
+    try:
+        conversation_template = ConversationTemplate.objects.get(id = pk)
+        if conversation_template.researcher != Researcher.objects.get(email=request.user.email):
+            return HttpResponse(status=401)
+
+        template_nodes = TemplateNode.objects.filter(parent_template=conversation_template)
+        model_JSON = json.dumps({
+            'name' : conversation_template.name,
+            'description' : conversation_template.description,
+            'nodes' : [
+                {
+                    'id' : node.id,
+                    'description' : node.description,
+                    'video_url' : node.video_url,
+                    'start' : node.start,
+                    'terminal' : node.terminal,
+                    'choices' : [
+                        {
+                            'choice_text' : choice.choice_text,
+                            'choice_destination' : "" if not choice.destination_node else choice.destination_node.id
+                        } for choice in TemplateNodeChoice.objects.filter(parent_template_node=node)
+                    ]
+                } for node in template_nodes
+            ]
+        })
+        return render(request, 'template_management/create_conversation_template.html', {'modelObject' : model_JSON })
+    except ConversationTemplate.DoesNotExist:
+        return HttpResponseNotFound()
+

--- a/simcon_project/templates/template_management/create_conversation_template.html
+++ b/simcon_project/templates/template_management/create_conversation_template.html
@@ -99,7 +99,12 @@
         </div>
     </div>
 
-    <script> loadState() </script>
+    <script>
+        if ("{{ modelObject }}") {
+            var modelObject = JSON.parse("{{modelObject|escapejs}}")
+        }
+        loadState()
+    </script>
     </body>
     </html>
 {% endblock %}

--- a/simcon_project/templates/template_management/create_conversation_template.html
+++ b/simcon_project/templates/template_management/create_conversation_template.html
@@ -1,3 +1,4 @@
+{% extends "researcher_base.html" %}
 {% load static %}
 {% block content %}
     <!DOCTYPE html>


### PR DESCRIPTION
Completed edit template functionality.

To test, create a template and navigate to
http://127.0.0.1:8000/researcher/templates/edit/<uidoftemplate>
eg: http://127.0.0.1:8000/researcher/templates/edit/aaee9d5c-3312-4a96-8e27-74e29121eff6

To get a template's id, you can overwrite conversation_template model's \_\_string\_\_ method to return id like so:
    def \_\_str\_\_(self):
        return f"{self.id}"
