### PR TITLE
Nothing displayed for feedback by default.

### DIFF
--- a/simcon_project/conversation_templates/models/template_response.py
+++ b/simcon_project/conversation_templates/models/template_response.py
@@ -21,7 +21,7 @@ class TemplateResponse(models.Model):
     student = models.ForeignKey('users.Student', related_name='template_responses', default=0, on_delete=models.CASCADE)
     template = models.ForeignKey('conversation_templates.ConversationTemplate', default=0, related_name='template_responses', on_delete=models.CASCADE)
     assignment = models.ForeignKey('users.Assignment', default=0, related_name='template_responses', on_delete=models.CASCADE)
-    feedback = models.CharField(max_length=1000, default=None, null=True, blank=True)
+    feedback = models.CharField(max_length=1000, default='', null=True, blank=True)
     self_rating = models.PositiveSmallIntegerField(default=0, null=True)
     archived = models.BooleanField(default=False)
     feedback_read = models.BooleanField(default=False)


### PR DESCRIPTION
To test:

- Run migrations
- Create new response (not sure if it will overwrite default feedback for old responses)