### PR TITLE
Disable subbmitting form with enter key in modals with input boxes

### DIFF
--- a/simcon_project/templates/student_creation_modal.html
+++ b/simcon_project/templates/student_creation_modal.html
@@ -23,5 +23,17 @@
         <button type="button" class="submit-btn btn btn-success">Send Invitation</button>
     </div>
 
+    <script>
+        $(document).on("keypress", 'form', function (e) {
+            var code = e.keyCode || e.which;
+            console.log(code);
+            if (code == 13) {
+                console.log('Inside');
+                e.preventDefault();
+                return false;
+            }
+        });
+    </script>
+
 </form>
 

--- a/simcon_project/templates/template_management/edit_folder_name_modal.html
+++ b/simcon_project/templates/template_management/edit_folder_name_modal.html
@@ -21,5 +21,16 @@
     <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
     <button type="button" class="submit-btn btn btn-success">Save</button>
   </div>
+  <script>
+    $(document).on("keypress", 'form', function (e) {
+        var code = e.keyCode || e.which;
+        console.log(code);
+        if (code == 13) {
+            console.log('Inside');
+            e.preventDefault();
+            return false;
+        }
+    });
+  </script>
 
 </form>


### PR DESCRIPTION
Disables submitting a form with the enter key for creating a student and editing a template name since it was causing a bug