### PR TITLE
removed recommended video popups

### DIFF
--- a/simcon_project/conversation_templates/models/template_node.py
+++ b/simcon_project/conversation_templates/models/template_node.py
@@ -31,5 +31,5 @@ class TemplateNode(models.Model):
         Adds nocookie to url to ignore if user is signed in to Google account.
         :return:
         """
-        parsed_url = urlparse(str(self.video_url)) #get video id. might only work for youtube.
+        parsed_url = urlparse(str(self.video_url))
         return "https://www.youtube-nocookie.com/embed/" + parsed_url[2][1:]

--- a/simcon_project/conversation_templates/models/template_node.py
+++ b/simcon_project/conversation_templates/models/template_node.py
@@ -1,6 +1,7 @@
 from django.db import models
 from embed_video.fields import EmbedVideoField
-from django.urls import reverse
+from embed_video.backends import detect_backend
+from urllib.parse import urlparse
 import uuid
 
 
@@ -25,3 +26,7 @@ class TemplateNode(models.Model):
 
     def __str__(self):
         return f"{self.parent_template}: {self.description}"
+
+    def get_no_cookie_url(self):
+        parsed_url = urlparse(str(self.video_url)) #get video id. might only work for youtube.
+        return "https://www.youtube-nocookie.com/embed/" + parsed_url[2][1:]

--- a/simcon_project/conversation_templates/models/template_node.py
+++ b/simcon_project/conversation_templates/models/template_node.py
@@ -1,6 +1,5 @@
 from django.db import models
 from embed_video.fields import EmbedVideoField
-from embed_video.backends import detect_backend
 from urllib.parse import urlparse
 import uuid
 
@@ -28,5 +27,9 @@ class TemplateNode(models.Model):
         return f"{self.parent_template}: {self.description}"
 
     def get_no_cookie_url(self):
+        """
+        Adds nocookie to url to ignore if user is signed in to Google account.
+        :return:
+        """
         parsed_url = urlparse(str(self.video_url)) #get video id. might only work for youtube.
         return "https://www.youtube-nocookie.com/embed/" + parsed_url[2][1:]

--- a/simcon_project/static/conversation_templates/create_conversation_template.js
+++ b/simcon_project/static/conversation_templates/create_conversation_template.js
@@ -461,7 +461,7 @@ function getEmbeddableUrl(url) {
     const match = url.match(REGEX)
     const regexedUrl = (match&&match[7].length==11)? match[7] : ""
     if(!(regexedUrl == "")) {
-        return "https://www.youtube.com/embed/" + regexedUrl
+        return "https://www.youtube-nocookie.com/embed/" + regexedUrl + "?rel=0&modestbranding=1&wmode=opaque"
     }
     return ""
 }

--- a/simcon_project/templates/conversation/conversation_step.html
+++ b/simcon_project/templates/conversation/conversation_step.html
@@ -28,7 +28,12 @@
                     <li class="list-group-item" style="text-align: center">
                         <div class="row justify-content-center mb-3">
                             <div id="videoPlayer">
-                                {% video ct_node.video_url%}
+                                <iframe width="480" height="360"
+                                        src="{{ ct_node.get_no_cookie_url }}?rel=0&modestbranding=1&wmode=opaque"
+                                        loading="lazy"
+                                        frameborder="0"
+                                        allowfullscreen="">
+                                </iframe>
                             </div>
                         </div>
 


### PR DESCRIPTION
Pain to test but I don't think there is another way to do this...use this unlisted video link during template creation: https://youtu.be/PEYUqRdPJWg (please ignore amazing computer graphics final....)
During a submission or during template creation, pause the video. There shouldn't be any popups for recommended videos. Same with when the video ends. It should just show a big red play button.