### PR TITLE
Added support for example conversation

### DIFF
--- a/simcon_project/conversation_templates/models/conv_template.py
+++ b/simcon_project/conversation_templates/models/conv_template.py
@@ -18,6 +18,7 @@ class ConversationTemplate(models.Model):
     id = models.UUIDField(unique=True, editable=False, primary_key=True, default=uuid.uuid4)
     name = models.CharField(max_length=100)
     description = models.CharField(max_length=4000)
+    example_conversation = models.CharField(max_length=4000, null=True, blank=True)
     creation_date = models.DateTimeField(default=timezone.now)
     researcher = models.ForeignKey('users.Researcher', related_name='templates', default=0, on_delete=models.CASCADE)
     archived = models.BooleanField(default=False)

--- a/simcon_project/conversation_templates/views/create_conversation_template_view.py
+++ b/simcon_project/conversation_templates/views/create_conversation_template_view.py
@@ -20,9 +20,14 @@ def create_conversation_template_view(request):
         body_unicode = request.body.decode('utf-8')
         body = json.loads(body_unicode)
 
+        example_conversation = body['exampleConversation']
+        if example_conversation == "":
+            example_conversation = None
+
         conv_template = ConversationTemplate(
             name=body['templateName'],
             description=body['templateDescription'],
+            example_conversation=example_conversation,
             researcher=Researcher.objects.get(email=request.user.email))
         conv_template.save()
 

--- a/simcon_project/conversation_templates/views/edit_conversation_template_view.py
+++ b/simcon_project/conversation_templates/views/edit_conversation_template_view.py
@@ -21,6 +21,7 @@ def edit_conversation_template(request, pk):
         model_JSON = json.dumps({
             'name' : conversation_template.name,
             'description' : conversation_template.description,
+            'example_conversation' : conversation_template.example_conversation,
             'nodes' : [
                 {
                     'id' : node.id,

--- a/simcon_project/templates/conversation/conversation_end.html
+++ b/simcon_project/templates/conversation/conversation_end.html
@@ -21,8 +21,6 @@
         <div class="card">
             <div class="card-body mr-3 ml-3">
 
-                {#                <p>{{ ct.description }}</p>#}
-                {#                {%  render_table ct_node_table %}#}
                 <div id="error"></div>
                 <form action="{{ ct_response.get_absolute_url }}" method="POST" id="trans-form">
                     <ul class="list-group list-group-flush">
@@ -39,6 +37,10 @@
                         </li>
                         {% if allow_self_rating %}
                             <li class="list-group-item">
+                                {% if ct.example_conversation %}
+                                    <h5 class="mb-3"><strong>Example Conversation:</strong></h5>
+                                    <p>{{ ct.example_conversation }}</p>
+                                {% endif %}
                                 <h5 class="mb-3"><strong>Rate your performance:</strong></h5>
                                 <label for="rating-very-unsatisfied" class="ml-2">
                                     <input type="radio" name="{{ ct_response.self_rating }}" id="rating-very-unsatisfied" value=1 class="mr-2">Very Unsatisfied

--- a/simcon_project/templates/template_management/create_conversation_template.html
+++ b/simcon_project/templates/template_management/create_conversation_template.html
@@ -77,6 +77,10 @@
                                 <label for="template-description-input">Template description:</label>
                                 <textarea class="form-control" id="template-description-input" data-toggle="tooltip" title=""></textarea>
                             </div>
+                            <div class="form-group">
+                                <label for="template-example-conversation-input">Example of a good conversation:</label>
+                                <textarea class="form-control" id="template-example-conversation-input" data-toggle="tooltip" title=""></textarea>
+                            </div>
                             <div class="form-check">
                                 <input type="checkbox" class="form-check-input" id="validate-check-input">
                                 <label class="form-check-label" for="validate-check-input">Validate</label>


### PR DESCRIPTION
Researchers can now leave behind 'example conversation' info which will show up when a student is completing the conversation.

Also, reversed the order of template node insertion during template editing. Postgres gives node objects in the opposite order of sqlite so when editing the nodes are linked correctly but render in the opposite order as to how they were  rendered when the page was originally created which is not super researcher-friendly haha

I have not tested with postgres, but my guess is that it is all good since things are showing up in reverse in sqlite (: