### PR TITLE
Fixed issue with certain youtube URL's not playing during submission.

### DIFF
--- a/simcon_project/conversation_templates/models/template_node.py
+++ b/simcon_project/conversation_templates/models/template_node.py
@@ -32,4 +32,7 @@ class TemplateNode(models.Model):
         :return:
         """
         parsed_url = urlparse(str(self.video_url))
-        return "https://www.youtube-nocookie.com/embed/" + parsed_url[2][1:]
+        if parsed_url[4] is not "":
+            return "https://www.youtube-nocookie.com/embed/" + parsed_url[4][2:]
+        else:
+            return "https://www.youtube-nocookie.com/embed/" + parsed_url[2][1:]


### PR DESCRIPTION
When making a template, add in two URL's for a video. One should come from the normal search bar at the top, the other comes from the "share" option just under the video. Both should show up correctly when you try to complete the template as a student. 